### PR TITLE
Handle missing elements in navigation script

### DIFF
--- a/laravel/public/js/script.js
+++ b/laravel/public/js/script.js
@@ -11,37 +11,41 @@ const fuse = new Fuse(rotas, {
 });
 
 const searchInput = document.getElementById("search-bar");
-searchInput.addEventListener("keydown", (e) => {
-  if (e.key === "Enter") {
-    const termo = searchInput.value.trim();
+if (searchInput) {
+  searchInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      const termo = searchInput.value.trim();
 
-    // caso nada tenha sido digitado
-    if (termo === "") {
-      // alert("Você precisa digitar algo antes de pesquisar.");
-      return;
-    }
+      // caso nada tenha sido digitado
+      if (termo === "") {
+        // alert("Você precisa digitar algo antes de pesquisar.");
+        return;
+      }
 
-    const result = fuse.search(termo);
-    if (result.length > 0) {
-      window.location.href = result[0].item.url;
-    } else {
-      window.location.href = "/nao-encontrado";
+      const result = fuse.search(termo);
+      if (result.length > 0) {
+        window.location.href = result[0].item.url;
+      } else {
+        window.location.href = "/nao-encontrado";
+      }
     }
-  }
-});
+  });
+}
 
 const btnLogin = document.getElementById("btn-login");
 const loginBox = document.getElementById("login-box");
 
-btnLogin.addEventListener("click", () => {
-  loginBox.classList.toggle("show");
-});
+if (btnLogin && loginBox) {
+  btnLogin.addEventListener("click", () => {
+    loginBox.classList.toggle("show");
+  });
 
-// Fecha se clicar fora
-document.addEventListener("click", (e) => {
-  if (!loginBox.contains(e.target) && !btnLogin.contains(e.target)) {
-    loginBox.classList.remove("show");
-  }
-});
+  // Fecha se clicar fora
+  document.addEventListener("click", (e) => {
+    if (!loginBox.contains(e.target) && !btnLogin.contains(e.target)) {
+      loginBox.classList.remove("show");
+    }
+  });
+}
 
 


### PR DESCRIPTION
## Summary
- guard navigation script event listeners so they only run when the corresponding DOM elements exist
- prevent runtime errors on pages such as Contato that do not include the search bar or login elements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b32a1164832f80ef172a14a5508b