### PR TITLE
Use anchor links for contact navigation cards

### DIFF
--- a/laravel/public/js/contato.js
+++ b/laravel/public/js/contato.js
@@ -1,27 +1,3 @@
-// 
-function faq() {
-    window.location.href = "/faq"
-}
-
-function suggestions() {
-    window.location.href = "/sugestoes"
-}
-
-function goHome() {
-    window.location.href = "/"
-};
-
-function talkToUs() {
-    window.location.href = "/fale-conosco"
-};
-
-function signUp() {
-  window.location.href = "/cadastro"
-};
-
-function recPass() {
-    window.location.href = "/recuperar-senha"
-};
 const questions = document.querySelectorAll('.faq-question');
 questions.forEach(q => {
     q.addEventListener('click', () => {

--- a/laravel/resources/views/cadastro.blade.php
+++ b/laravel/resources/views/cadastro.blade.php
@@ -15,7 +15,7 @@
         <nav class="navbar navbar-expand-lg bg-body-tertiary">
             <div class="container">
                 <a class="navbar-brand d-flex align-items-center gap-2" href="{{ route('home') }}">
-                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" onclick="goHome()" />
+                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" />
                     <span>ReciclaBits</span>
                 </a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"

--- a/laravel/resources/views/contato.blade.php
+++ b/laravel/resources/views/contato.blade.php
@@ -17,7 +17,7 @@
         <nav class="navbar navbar-expand-lg bg-body-tertiary">
             <div class="container">
                 <a class="navbar-brand d-flex align-items-center gap-2" href="{{ route('home') }}">
-                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" onclick="goHome()"/>
+                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" />
                     <span>ReciclaBits</span>
                 </a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
@@ -40,32 +40,32 @@
             <div class="container">
                 <div class="row g-4 cards">
                     <!-- Card 1 -->
-                    <div class="col-12 col-md-6 col-lg-4 cardzin" onclick="faq()">
+                    <a class="col-12 col-md-6 col-lg-4 cardzin" href="{{ route('faq') }}">
                         <article class="card faq-card h-100">
                             <img class="faq-img" src="{{ asset('img/help.png') }}" alt="" />
                             <div class="card-body">
                                 <h2>Dúvidas</h2>
                             </div>
                         </article>
-                    </div>
+                    </a>
                     <!-- Card 2 -->
-                    <div class="col-12 col-md-6 col-lg-4 cardzin" onclick="suggestions()">
+                    <a class="col-12 col-md-6 col-lg-4 cardzin" href="{{ route('suggestions') }}">
                         <article class="card faq-card h-100">
                             <img class="faq-img" src="{{ asset('img/question.png') }}" alt="" />
                             <div class="card-body">
                                 <h2>Sugestões</h2>
                             </div>
                         </article>
-                    </div>
+                    </a>
                     <!-- Card 3 -->
-                    <div class="col-12 col-md-6 col-lg-4 cardzin" onclick="talkToUs()">
+                    <a class="col-12 col-md-6 col-lg-4 cardzin" href="{{ route('talk-to-us') }}">
                         <article class="card faq-card h-100">
                             <img class="faq-img" src="{{ asset('img/phone-call.png') }}" alt="" />
                             <div class="card-body">
                                 <h2>Fale conosco</h2>
                             </div>
                         </article>
-                    </div>
+                    </a>
                 </div>
             </div>
         </section>

--- a/laravel/resources/views/faq.blade.php
+++ b/laravel/resources/views/faq.blade.php
@@ -17,7 +17,7 @@
         <nav class="navbar navbar-expand-lg bg-body-tertiary">
             <div class="container">
                 <a class="navbar-brand d-flex align-items-center gap-2" href="{{ route('home') }}">
-                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" onclick="goHome()" />
+                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" />
                     <span>ReciclaBits</span>
                 </a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"

--- a/laravel/resources/views/home.blade.php
+++ b/laravel/resources/views/home.blade.php
@@ -22,7 +22,7 @@
     <nav class="navbar navbar-expand-lg bg-body-tertiary">
       <div class="container">
         <a class="navbar-brand d-flex align-items-center gap-2" href="{{ route('home') }}">
-          <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" onclick="goHome()" />
+          <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" />
           <span>ReciclaBits</span>
         </a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
@@ -54,7 +54,7 @@
               <a href="{{ route('password.recovery') }}" class="small d-block mb-2">Esqueceu sua senha?</a>
               <button type="submit" class="btn btn-success w-100">Entrar</button>
               <p class="mt-3 text-center small">Não tem cadastro?</p>
-              <button type="button" class="btn btn-primary w-100" onclick="signUp()">Cadastre-se</button>
+              <a class="btn btn-primary w-100" href="{{ route('cadastro') }}">Cadastre-se</a>
             </form>
           </div>
         </div>

--- a/laravel/resources/views/map.blade.php
+++ b/laravel/resources/views/map.blade.php
@@ -16,7 +16,7 @@
         <nav class="navbar navbar-expand-lg bg-body-tertiary">
             <div class="container">
                 <a class="navbar-brand d-flex align-items-center gap-2" href="{{ route('home') }}">
-                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" onclick="goHome()"/>
+                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo"/>
                     <span>ReciclaBits</span>
                 </a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"

--- a/laravel/resources/views/notFound.blade.php
+++ b/laravel/resources/views/notFound.blade.php
@@ -13,7 +13,7 @@
         <nav class="navbar navbar-expand-lg bg-body-tertiary">
             <div class="container">
                 <a class="navbar-brand d-flex align-items-center gap-2" href="{{ route('home') }}">
-                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" onclick="goHome()" />
+                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" />
                     <span>ReciclaBits</span>
                 </a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
@@ -39,21 +39,21 @@
             <div class="container">
                 <div class="row g-4 cards">
                     <!-- Card 1 -->
-                    <div class="col-12 col-md-6 col-lg-4 link" onclick="suggestions()">
+                    <a class="col-12 col-md-6 col-lg-4 link" href="{{ route('suggestions') }}">
                         <article class="card faq-card h-100">
                             <div class="card-body">
                                 <h2>Sugestões</h2>
                             </div>
                         </article>
-                    </div>
+                    </a>
                     <!-- Card 2 -->
-                    <div class="col-12 col-md-6 col-lg-4 link" onclick="faq()">
+                    <a class="col-12 col-md-6 col-lg-4 link" href="{{ route('faq') }}">
                         <article class="card faq-card h-100">
                             <div class="card-body">
                                 <h2>Dúvidas?</h2>
                             </div>
                         </article>
-                    </div>                   
+                    </a>
                 </div>
     </main>
     <footer id="contato">

--- a/laravel/resources/views/passwordRec.blade.php
+++ b/laravel/resources/views/passwordRec.blade.php
@@ -14,7 +14,7 @@
         <nav class="navbar navbar-expand-lg bg-body-tertiary">
             <div class="container">
                 <a class="navbar-brand d-flex align-items-center gap-2" href="{{ route('home') }}">
-                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" onclick="goHome()" />
+                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" />
                     <span>ReciclaBits</span>
                 </a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"

--- a/laravel/resources/views/sobreNos.blade.php
+++ b/laravel/resources/views/sobreNos.blade.php
@@ -15,7 +15,7 @@
     <nav class="navbar navbar-expand-lg bg-body-tertiary">
       <div class="container">
         <a class="navbar-brand d-flex align-items-center gap-2" href="{{ route('home') }}">
-          <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" onclick="goHome()" />
+          <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" />
           <span>ReciclaBits</span>
         </a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"

--- a/laravel/resources/views/suggestions.blade.php
+++ b/laravel/resources/views/suggestions.blade.php
@@ -15,7 +15,7 @@
         <nav class="navbar navbar-expand-lg bg-body-tertiary">
             <div class="container">
                 <a class="navbar-brand d-flex align-items-center gap-2" href="{{ route('home') }}">
-                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo" onclick="goHome()"/>
+                    <img src="{{ asset('img/ReciclaBits.png') }}" alt="logo" class="logo"/>
                     <span>ReciclaBits</span>
                 </a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"


### PR DESCRIPTION
## Summary
- wrap the contact and not-found shortcut cards with anchor tags pointing to their named routes
- remove the unused navigation helper functions from `public/js/contato.js`
- replace inline navigation onclick handlers with native anchor links, including the sign-up button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da6eff57a4832fa12d500b1a2685af