### PR TITLE
Add migration for sessions table

### DIFF
--- a/laravel/database/migrations/0001_01_01_000003_create_sessions_table.php
+++ b/laravel/database/migrations/0001_01_01_000003_create_sessions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sessions', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->longText('payload');
+            $table->integer('last_activity')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sessions');
+    }
+};


### PR DESCRIPTION
## Summary
- add a database migration that creates the sessions table used by the database session driver

## Testing
- not run (composer install requires GitHub access that is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68da76f65c48832f8680f5e738356306